### PR TITLE
Fix vault paths/add itest code coverage/update itest deps

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -16,3 +16,20 @@ jobs:
 
       - name: Run tests in docker container
         run:  make docker-test-all
+
+      - name: Upload unit test coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: cover.out
+          parallel: true
+
+      - name: Upload integration test coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: icover.out
+          parallel: true
+
+      - name: Generate coverage badge
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ ifeq ($(CPLATFORM), arm64)
 endif 
 
 GOVER         := 1.20.3
-LND           := v0.16.2-beta
-BITCOIND      := 24.0.1
-VAULT         := 1.12.2
+LND           := v0.17.3-beta
+BITCOIND      := 26.0
+VAULT         := 1.15.4
 
 # docker builds a builder image for the host platform if one isn't cached.
 docker:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Next, get the account list for the node (this works on Linux with `jq` installed
 
 ```
 ~/.lnd-watchonly$ VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=root \
-   vault read lndsigner/lnd-nodes/accounts node=*pubkey* | \
+   vault read lndsigner/lnd-nodes/*pubkey*/accounts | \
    tail -n 1 | sed s/acctList\\s*// | jq > accounts.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/aakselrod/lndsigner/badge.svg?branch=main)](https://coveralls.io/github/aakselrod/lndsigner?branch=main)
+
 # lndsigner
 `lndsigner` is a [remote signer](https://github.com/lightningnetwork/lnd/blob/master/docs/remote-signing.md) for [lnd](https://github.com/lightningnetwork/lnd). Currently, it can do the following:
 - [x] store seeds for multiple nodes in [Hashicorp Vault](https://github.com/hashicorp/vault/)

--- a/itest/itest_lndharness_test.go
+++ b/itest/itest_lndharness_test.go
@@ -14,8 +14,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/nydig-oss/lndsigner"
-	"github.com/nydig-oss/lndsigner/itest"
 	"io/fs"
 	"math/big"
 	"net"
@@ -24,6 +22,9 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/nydig-oss/lndsigner"
+	"github.com/nydig-oss/lndsigner/itest"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -95,7 +96,12 @@ func (l *lndHarness) Start() {
 	l.lndSignerCmd.Env = append(l.lndSignerCmd.Env,
 		"VAULT_ADDR=http://127.0.0.1:"+l.tctx.vaultPort,
 		"VAULT_TOKEN=root",
+		"GOCOVERDIR="+path.Join(os.Getenv("GOCOVERDIR"), "lndsignerd"),
 	)
+
+	l.lndSignerCmd.Cancel = func() error {
+		return l.lndSignerCmd.Process.Signal(os.Interrupt)
+	}
 
 	go waitProc(l.lndSignerCmd)
 
@@ -265,7 +271,9 @@ func waitFile(t *testing.T, file, waitStr string) {
 // exit error, the program's entire stderr and stdout are logged.
 func waitProc(cmd *exec.Cmd) {
 	output, err := cmd.CombinedOutput()
-	if err != nil && err.Error() != "signal: killed" {
+	if err != nil && err.Error() != "signal: killed" &&
+		err != context.Canceled {
+
 		config := zap.NewDevelopmentConfig()
 		config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		config.EncoderConfig.EncodeCaller = nil

--- a/itest/itest_lndharness_test.go
+++ b/itest/itest_lndharness_test.go
@@ -100,11 +100,8 @@ func (l *lndHarness) Start() {
 	go waitProc(l.lndSignerCmd)
 
 	// Start lnd.
-	acctsResp, err := l.tctx.vaultClient.ReadWithData(
-		"lndsigner/lnd-nodes/accounts",
-		map[string][]string{
-			"node": []string{l.idPubKey},
-		},
+	acctsResp, err := l.tctx.vaultClient.Read(
+		"lndsigner/lnd-nodes/" + l.idPubKey + "/accounts",
 	)
 	require.NoError(l.tctx.t, err)
 

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -112,7 +112,6 @@ func (k *KeyRing) ECDH(keyDesc KeyDescriptor, pub *btcec.PublicKey) ([32]byte,
 	error) {
 
 	reqData := map[string]interface{}{
-		"node": k.node,
 		"path": []int{
 			int(vault.Bip0043purpose +
 				hdkeychain.HardenedKeyStart),
@@ -133,7 +132,7 @@ func (k *KeyRing) ECDH(keyDesc KeyDescriptor, pub *btcec.PublicKey) ([32]byte,
 	log.Debugf("Sending data %+v for shared key request", reqData)
 
 	sharedKeyResp, err := k.client.Write(
-		"lndsigner/lnd-nodes/ecdh",
+		"lndsigner/lnd-nodes/"+k.node+"/ecdh",
 		reqData,
 	)
 	if err != nil {
@@ -176,7 +175,6 @@ func (k *KeyRing) SignMessage(keyLoc KeyLocator, msg []byte, doubleHash bool,
 	}
 
 	reqData := map[string]interface{}{
-		"node": k.node,
 		"path": []int{
 			int(vault.Bip0043purpose + hdkeychain.HardenedKeyStart),
 			int(k.coin + hdkeychain.HardenedKeyStart),
@@ -195,7 +193,7 @@ func (k *KeyRing) SignMessage(keyLoc KeyLocator, msg []byte, doubleHash bool,
 	log.Debugf("Sending data %+v for signing request", reqData)
 
 	signResp, err := k.client.Write(
-		"lndsigner/lnd-nodes/sign",
+		"lndsigner/lnd-nodes/"+k.node+"/sign",
 		reqData,
 	)
 	if err != nil {
@@ -226,7 +224,6 @@ func (k *KeyRing) SignMessageSchnorr(keyLoc KeyLocator, msg []byte,
 	}
 
 	reqData := map[string]interface{}{
-		"node": k.node,
 		"path": []int{
 			int(vault.Bip0043purpose + hdkeychain.HardenedKeyStart),
 			int(k.coin + hdkeychain.HardenedKeyStart),
@@ -245,7 +242,7 @@ func (k *KeyRing) SignMessageSchnorr(keyLoc KeyLocator, msg []byte,
 	log.Debugf("Sending data %+v for signing request", reqData)
 
 	signResp, err := k.client.Write(
-		"lndsigner/lnd-nodes/sign",
+		"lndsigner/lnd-nodes/"+k.node+"/sign",
 		reqData,
 	)
 	if err != nil {
@@ -395,7 +392,6 @@ func (k *KeyRing) signSegWitV0(in *psbt.PInput, tx *wire.MsgTx,
 		in.Unknowns)
 
 	reqData := map[string]interface{}{
-		"node":   k.node,
 		"path":   sliceUint32ToInt(in.Bip32Derivation[0].Bip32Path),
 		"method": "ecdsa",
 		"digest": hex.EncodeToString(digest),
@@ -406,7 +402,7 @@ func (k *KeyRing) signSegWitV0(in *psbt.PInput, tx *wire.MsgTx,
 	log.Debugf("Sending data %+v for signing request", reqData)
 
 	signResp, err := k.client.Write(
-		"lndsigner/lnd-nodes/sign",
+		"lndsigner/lnd-nodes/"+k.node+"/sign",
 		reqData,
 	)
 	if err != nil {
@@ -465,7 +461,6 @@ func (k *KeyRing) signSegWitV1KeySpend(in *psbt.PInput, tx *wire.MsgTx,
 	}
 
 	reqData := map[string]interface{}{
-		"node":     k.node,
 		"path":     sliceUint32ToInt(in.Bip32Derivation[0].Bip32Path),
 		"method":   "schnorr",
 		"digest":   hex.EncodeToString(digest),
@@ -477,7 +472,7 @@ func (k *KeyRing) signSegWitV1KeySpend(in *psbt.PInput, tx *wire.MsgTx,
 	log.Debugf("Sending data %+v for signing request", reqData)
 
 	signResp, err := k.client.Write(
-		"lndsigner/lnd-nodes/sign",
+		"lndsigner/lnd-nodes/"+k.node+"/sign",
 		reqData,
 	)
 	if err != nil {
@@ -523,7 +518,6 @@ func (k *KeyRing) signSegWitV1ScriptSpend(in *psbt.PInput, tx *wire.MsgTx,
 	}
 
 	reqData := map[string]interface{}{
-		"node":   k.node,
 		"path":   sliceUint32ToInt(in.Bip32Derivation[0].Bip32Path),
 		"method": "schnorr",
 		"digest": hex.EncodeToString(digest),
@@ -534,7 +528,7 @@ func (k *KeyRing) signSegWitV1ScriptSpend(in *psbt.PInput, tx *wire.MsgTx,
 	log.Debugf("Sending data %+v for signing request", reqData)
 
 	signResp, err := k.client.Write(
-		"lndsigner/lnd-nodes/sign",
+		"lndsigner/lnd-nodes/"+k.node+"/sign",
 		reqData,
 	)
 	if err != nil {

--- a/keyring/keyring_test.go
+++ b/keyring/keyring_test.go
@@ -122,11 +122,10 @@ func TestECDH(t *testing.T) {
 				data map[string]interface{}) (*api.Secret,
 				error) {
 
-				require.Equal(t, "lndsigner/lnd-nodes/ecdh",
-					path)
+				require.Equal(t, "lndsigner/lnd-nodes/"+
+					keyRing.node+"/ecdh", path)
 
 				require.Equal(t, map[string]interface{}{
-					"node": keyRing.node,
 					"path": []int{2147484665, 2147483649,
 						2147483654, 0, 0},
 					"peer":   peerPubHex,
@@ -168,7 +167,6 @@ func TestSignMessage(t *testing.T) {
 		{
 			name: "sign single",
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "ecdsa",
@@ -183,7 +181,6 @@ func TestSignMessage(t *testing.T) {
 			name:       "sign double",
 			doubleHash: true,
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "ecdsa",
@@ -198,7 +195,6 @@ func TestSignMessage(t *testing.T) {
 			name:    "sign single compact",
 			compact: true,
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "ecdsa-compact",
@@ -214,7 +210,6 @@ func TestSignMessage(t *testing.T) {
 			doubleHash: true,
 			compact:    true,
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "ecdsa-compact",
@@ -228,7 +223,6 @@ func TestSignMessage(t *testing.T) {
 		{
 			name: "error on request",
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "ecdsa",
@@ -240,7 +234,6 @@ func TestSignMessage(t *testing.T) {
 		{
 			name: ErrNoSignatureReturned.Error(),
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "ecdsa",
@@ -251,7 +244,6 @@ func TestSignMessage(t *testing.T) {
 		{
 			name: "signature not hex",
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "ecdsa",
@@ -270,8 +262,8 @@ func TestSignMessage(t *testing.T) {
 				data map[string]interface{}) (*api.Secret,
 				error) {
 
-				require.Equal(t, "lndsigner/lnd-nodes/sign",
-					path)
+				require.Equal(t, "lndsigner/lnd-nodes/"+
+					keyRing.node+"/sign", path)
 
 				require.Equal(t, testCase.reqData, data)
 
@@ -311,7 +303,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 		{
 			name: "sign single",
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -326,7 +317,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 			name:       "sign double",
 			doubleHash: true,
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -340,7 +330,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 		{
 			name: "sign single tweaked",
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -355,7 +344,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 			name:       "sign double tweaked",
 			doubleHash: true,
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -369,7 +357,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 		{
 			name: "error on request",
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -381,7 +368,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 		{
 			name: ErrNoSignatureReturned.Error(),
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -392,7 +378,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 		{
 			name: "signature not hex",
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -406,7 +391,6 @@ func TestSignMessageSchnorr(t *testing.T) {
 		{
 			name: schnorr.ErrSigTooShort.Error(),
 			reqData: map[string]interface{}{
-				"node": keyRing.node,
 				"path": []int{2147484665, 2147483649,
 					2147483654, 0, 0},
 				"method": "schnorr",
@@ -428,8 +412,8 @@ func TestSignMessageSchnorr(t *testing.T) {
 				data map[string]interface{}) (*api.Secret,
 				error) {
 
-				require.Equal(t, "lndsigner/lnd-nodes/sign",
-					path)
+				require.Equal(t, "lndsigner/lnd-nodes/"+
+					keyRing.node+"/sign", path)
 
 				require.Equal(t, testCase.reqData, data)
 
@@ -473,7 +457,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "p2tr spend",
 			packet: p2trPsbt,
 			reqData: map[string]interface{}{
-				"node":     keyRing.node,
 				"digest":   "6a14f55652583393923a9f6909c9be3ada3e5bd724c324d8a554b823388491ad",
 				"path":     []int{2147483734, 2147483648, 2147483648, 0, 0},
 				"method":   "schnorr",
@@ -488,7 +471,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "p2wkh spend",
 			packet: p2wkhPsbt,
 			reqData: map[string]interface{}{
-				"node":   keyRing.node,
 				"digest": "2046c479fa1d00033ff7239086071cb4abadc2c99e2dd14e6e1af7ed8060f3ca",
 				"path":   []int{2147483732, 2147483648, 2147483648, 0, 0},
 				"method": "ecdsa",
@@ -503,7 +485,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "np2wkh spend",
 			packet: np2wkhPsbt,
 			reqData: map[string]interface{}{
-				"node":   keyRing.node,
 				"digest": "5f5c0b1eb31d60a15c0b607ee037b97bbb2ef375d127be13c4718ddc5b67dc70",
 				"path":   []int{2147483697, 2147483648, 2147483648, 0, 0},
 				"method": "ecdsa",
@@ -518,7 +499,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "ln1tweak spend",
 			packet: tweak1Psbt,
 			reqData: map[string]interface{}{
-				"node":     keyRing.node,
 				"digest":   "acf17dc76b84ab1b061f274ccea1b680e7195d34f138c92bec64f66a6ed11b7c",
 				"ln1tweak": "cf374dcf99541cff08176226b16e1848eee7f00430da428a74ddc671224bbe8f",
 				"path":     []int{2147484665, 2147483649, 2147483650, 0, 0},
@@ -534,7 +514,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   ErrNoPubkeyReturned.Error(),
 			packet: np2wkhPsbt,
 			reqData: map[string]interface{}{
-				"node":   keyRing.node,
 				"digest": "5f5c0b1eb31d60a15c0b607ee037b97bbb2ef375d127be13c4718ddc5b67dc70",
 				"path":   []int{2147483697, 2147483648, 2147483648, 0, 0},
 				"method": "ecdsa",
@@ -548,7 +527,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "pubkey not hex",
 			packet: np2wkhPsbt,
 			reqData: map[string]interface{}{
-				"node":   keyRing.node,
 				"digest": "5f5c0b1eb31d60a15c0b607ee037b97bbb2ef375d127be13c4718ddc5b67dc70",
 				"path":   []int{2147483697, 2147483648, 2147483648, 0, 0},
 				"method": "ecdsa",
@@ -563,7 +541,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "p2wkh and np2wkh error on request",
 			packet: np2wkhPsbt,
 			reqData: map[string]interface{}{
-				"node":   keyRing.node,
 				"digest": "5f5c0b1eb31d60a15c0b607ee037b97bbb2ef375d127be13c4718ddc5b67dc70",
 				"path":   []int{2147483697, 2147483648, 2147483648, 0, 0},
 				"method": "ecdsa",
@@ -575,7 +552,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "np2wkh and p2wkh " + ErrNoSignatureReturned.Error(),
 			packet: np2wkhPsbt,
 			reqData: map[string]interface{}{
-				"node":   keyRing.node,
 				"digest": "5f5c0b1eb31d60a15c0b607ee037b97bbb2ef375d127be13c4718ddc5b67dc70",
 				"path":   []int{2147483697, 2147483648, 2147483648, 0, 0},
 				"method": "ecdsa",
@@ -586,7 +562,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "np2wkh and p2wkh signature not hex",
 			packet: np2wkhPsbt,
 			reqData: map[string]interface{}{
-				"node":   keyRing.node,
 				"digest": "5f5c0b1eb31d60a15c0b607ee037b97bbb2ef375d127be13c4718ddc5b67dc70",
 				"path":   []int{2147483697, 2147483648, 2147483648, 0, 0},
 				"method": "ecdsa",
@@ -600,7 +575,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "p2wkh and np2wkh error on request",
 			packet: p2trPsbt,
 			reqData: map[string]interface{}{
-				"node":     keyRing.node,
 				"digest":   "6a14f55652583393923a9f6909c9be3ada3e5bd724c324d8a554b823388491ad",
 				"path":     []int{2147483734, 2147483648, 2147483648, 0, 0},
 				"method":   "schnorr",
@@ -613,7 +587,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "p2tr " + ErrNoSignatureReturned.Error(),
 			packet: p2trPsbt,
 			reqData: map[string]interface{}{
-				"node":     keyRing.node,
 				"digest":   "6a14f55652583393923a9f6909c9be3ada3e5bd724c324d8a554b823388491ad",
 				"path":     []int{2147483734, 2147483648, 2147483648, 0, 0},
 				"method":   "schnorr",
@@ -625,7 +598,6 @@ func TestSignPsbt(t *testing.T) {
 			name:   "p2tr signature not hex",
 			packet: p2trPsbt,
 			reqData: map[string]interface{}{
-				"node":     keyRing.node,
 				"digest":   "6a14f55652583393923a9f6909c9be3ada3e5bd724c324d8a554b823388491ad",
 				"path":     []int{2147483734, 2147483648, 2147483648, 0, 0},
 				"method":   "schnorr",
@@ -644,8 +616,8 @@ func TestSignPsbt(t *testing.T) {
 				data map[string]interface{}) (*api.Secret,
 				error) {
 
-				require.Equal(t, "lndsigner/lnd-nodes/sign",
-					path)
+				require.Equal(t, "lndsigner/lnd-nodes/"+
+					keyRing.node+"/sign", path)
 
 				require.Equal(t, testCase.reqData, data)
 

--- a/vault/paths.go
+++ b/vault/paths.go
@@ -90,7 +90,7 @@ POST - import existing LND node into vault with seedphrase and passphrase
 
 func (b *backend) accountsPath() *framework.Path {
 	return &framework.Path{
-		Pattern: "lnd-nodes/accounts/?",
+		Pattern: "lnd-nodes/(?P<node>[[:xdigit:]]{66})/accounts/?",
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: wrapOp(b.listAccounts),
 		},
@@ -115,7 +115,7 @@ only LND
 
 func (b *backend) ecdhPath() *framework.Path {
 	return &framework.Path{
-		Pattern: "lnd-nodes/ecdh/?",
+		Pattern: "lnd-nodes/(?P<node>[[:xdigit:]]{66})/ecdh/?",
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: wrapOp(b.ecdh),
 		},
@@ -160,7 +160,7 @@ peer pubkey
 
 func (b *backend) signPath() *framework.Path {
 	return &framework.Path{
-		Pattern: "lnd-nodes/sign/?",
+		Pattern: "lnd-nodes/(?P<node>[[:xdigit:]]{66})/sign/?",
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation:   wrapOp(b.derivePubKey),
 			logical.UpdateOperation: wrapOp(b.deriveAndSign),


### PR DESCRIPTION
This PR updates the `vault` plugin paths to ensure that the node ID is in the path rather than in query parameters for the methods `sign`, `ecdh`, and `accounts`. This allows the node ID to be specified in granular ACLs to allow user assignment with various privileges to nodes.

For example, a user can have access to `lnd-nodes/nodeApubkey` but not `lnd-nodes/nodeBpubkey`. Alternatively, a user could have access to `lnd-nodes/nodeApubkey/ecdh` and `lnd-nodes/nodeApubkey/accounts`, but not `lnd-nodes/nodeApubkey/sign`, while having access to all of `lnd-nodes/nodeBpubkey` paths.

The PR also updates tests to work with the new path format, the README.md instructions, and adds an integration test to show that the node specified in the path isn't overridden by a query parameter specifying the node. This fixes NYDIG-OSS/lndsigner#22.

The PR then updates `vault`, `lnd` and `bitcoind` to the latest version.

Finally, the PR updates the integration tests to ensure `lndsignerd` and `vault-plugin-lndsigner` exit cleanly at the end of the tests, and enables coverage analysis on the integration tests. This fixes NYDIG-OSS/lndsigner#21.